### PR TITLE
Mejora para la detección de la distribución Linux.

### DIFF
--- a/Java/UT00Utilidades/src/es/iesclaradelrey/dm2e2223/ut00utilidades/DeteccionSistemaOperativo.java
+++ b/Java/UT00Utilidades/src/es/iesclaradelrey/dm2e2223/ut00utilidades/DeteccionSistemaOperativo.java
@@ -1,8 +1,8 @@
 package es.iesclaradelrey.dm2e2223.ut00utilidades;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStreamReader;
 
 
 /**
@@ -26,12 +26,19 @@ public class DeteccionSistemaOperativo {
 	}
 
 	private static SistemaOperativo DetectarDistroLinux() {
+		String[] cmd = {"/bin/sh", "-c", "cat /etc/os-release | grep '^NAME'"};
+		String distro = "";
 		try {
-			String contenidoEtcIssue = Files.readString(Path.of("/etc/issue")).toLowerCase();
-			if (contenidoEtcIssue.contains("ubuntu")) return SistemaOperativo.UBUNTU;
+			Process p = Runtime.getRuntime().exec(cmd);
+			BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			if ((distro = br.readLine()) == null) return SistemaOperativo.LINUX_DISTRO;
+			distro = distro.replace("NAME=", "").replaceAll("\"", "");
+			br.close();
 		} catch (IOException e) {
+			e.printStackTrace();
 		}
-		return SistemaOperativo.LINUX_GENERIC;
+		System.out.println(distro);
+		return  SistemaOperativo.LINUX_DISTRO;
 	}
 	
 	

--- a/Java/UT00Utilidades/src/es/iesclaradelrey/dm2e2223/ut00utilidades/SistemaOperativo.java
+++ b/Java/UT00Utilidades/src/es/iesclaradelrey/dm2e2223/ut00utilidades/SistemaOperativo.java
@@ -2,7 +2,7 @@ package es.iesclaradelrey.dm2e2223.ut00utilidades;
 
 public enum SistemaOperativo {
 	WINDOWS,
-	LINUX_GENERIC,
+	LINUX_DISTRO,
 	UBUNTU,
 	KUBUNTU,
 	DESCONOCIDO


### PR DESCRIPTION
He intentado modificar lo menos posible el código. Me gustaría haber utilizado el enum de la misma forma que se estaba utilizando pero no he conseguido añadir elementos al enum de forma dinámica y es por ello que simplemente imprime por pantalla un String con el nombre de la distro.